### PR TITLE
fix(build): аннотации JetBrains попадают в выпускаемые пакеты

### DIFF
--- a/.claude/rules/project-map.md
+++ b/.claude/rules/project-map.md
@@ -30,9 +30,18 @@ build/                     Nuke-сборка: Build.cs, цели DotNetPack и P
 ```
 
 Решение — `GlavLib.sln`. Общие настройки сборки — `Directory.Build.props` (`net10.0`,
-`Nullable`, `TreatWarningsAsErrors`), `Directory.Build.targets` (подключение `NullGuard.Fody`
-и автоматическое включение `_errors/*` в `AdditionalFiles`), версии пакетов —
-`Directory.Packages.props` (центральное управление версиями, в `csproj` версии не пишутся).
+`Nullable`, `TreatWarningsAsErrors`, константа компиляции `JETBRAINS_ANNOTATIONS`),
+`Directory.Build.targets` (подключение `NullGuard.Fody` и автоматическое включение `_errors/*`
+в `AdditionalFiles`), версии пакетов — `Directory.Packages.props` (центральное управление
+версиями, в `csproj` версии не пишутся).
+
+Константа `JETBRAINS_ANNOTATIONS` определена на всё решение и снимать её нельзя. Атрибуты
+пакета `JetBrains.Annotations` помечены `[Conditional("JETBRAINS_ANNOTATIONS")]`, поэтому без
+этой константы компилятор выбрасывает их применение из выходной сборки: в метаданных пакетов
+не остаётся ни `[PublicAPI]`, ни `[UsedImplicitly]`, и у потребителей библиотеки подсказки
+IDE не работают — например, Rider сообщает «Class is never instantiated» на наследниках
+`EnumObject`. Задаётся она с сохранением `$(DefineConstants)`, чтобы не затереть `DEBUG`
+и `TRACE`, которые SDK добавляет позже.
 
 ## Зависимости сборок
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,5 +6,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <ImplicitUsings>enable</ImplicitUsings>
+    <DefineConstants>$(DefineConstants);JETBRAINS_ANNOTATIONS</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/GlavLib.Abstractions/DataTypes/EnumObject.cs
+++ b/GlavLib.Abstractions/DataTypes/EnumObject.cs
@@ -1,8 +1,5 @@
-using JetBrains.Annotations;
-
 namespace GlavLib.Abstractions.DataTypes;
 
-[UsedImplicitly(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature, ImplicitUseTargetFlags.WithInheritors)]
 public abstract class EnumObject(
         string key,
         string displayName

--- a/GlavLib.Abstractions/DataTypes/EnumObjectItemAttribute.cs
+++ b/GlavLib.Abstractions/DataTypes/EnumObjectItemAttribute.cs
@@ -1,6 +1,9 @@
-﻿namespace GlavLib.Abstractions.DataTypes;
+﻿using JetBrains.Annotations;
+
+namespace GlavLib.Abstractions.DataTypes;
 
 [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
+[MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]
 public class EnumObjectItemAttribute : Attribute
 {
     public string FieldName { get; set; }


### PR DESCRIPTION
## Что изменилось

В `Directory.Build.props` на всё решение определена константа компиляции `JETBRAINS_ANNOTATIONS` — с сохранением `$(DefineConstants)`, чтобы не затереть `DEBUG` и `TRACE`, которые SDK добавляет позже.

`EnumObjectItemAttribute` помечен `[MeansImplicitUse(ImplicitUseKindFlags.InstantiatedNoFixedConstructorSignature)]`. Теперь признак «этот класс всё-таки создаётся» следует из атрибута `[EnumObjectItem]`, который стоит прямо на классе потребителя.

С базового класса `EnumObject` снят атрибут `[UsedImplicitly(..., ImplicitUseTargetFlags.WithInheritors)]`, решавший ту же задачу через распространение неявного использования от базового класса к наследникам. Два механизма одновременно не нужны, а оставшийся точнее по существу: генератор `EnumObjectSourceGenerator` работает только при наличии хотя бы одного `[EnumObjectItem]`, и для наследника `EnumObject` без этого атрибута он не выпускает ни одного экземпляра — предупреждение «класс никогда не инстанцируется» на таком классе справедливо, и гасить его аннотацией базового типа было неверно.

## Зачем

Атрибуты пакета `JetBrains.Annotations` помечены `[Conditional("JETBRAINS_ANNOTATIONS")]`. Если одноимённая константа компиляции не определена, компилятор C# выбрасывает применение таких атрибутов из выходной сборки. Внутри этого решения атрибуты при этом продолжают работать — Rider читает их из исходного кода, — поэтому проблема и оставалась незаметной: ломается только у потребителей пакетов, которые видят лишь метаданные `.dll`.

Проверено чтением метаданных типа `GlavLib.Abstractions.DataTypes.EnumObject` в трёх сборках:

| Сборка | Атрибуты на `EnumObject` |
|---|---|
| Пакет с nuget.org `GlavLib.Abstractions 2026.8.20.129` (коммит `fd7c2e1a`) | `NullableContext`, `Nullable` |
| Локальная сборка до этой правки | `NullableContext`, `Nullable` |
| Локальная сборка с определённой константой | `NullableContext`, `Nullable`, `JetBrains.Annotations.UsedImplicitlyAttribute` |

Из-за этого у потребителей библиотеки Rider сообщал «Class is never instantiated» на классах, унаследованных от `EnumObject`, несмотря на добавленный ранее `[UsedImplicitly]`. Тем же механизмом до потребителей не доезжали и двадцать семь атрибутов `[PublicAPI]`, расставленных в упаковываемых сборках, — они не работали вообще.

Само предупреждение возникает при работающем генераторе потому, что экземпляры создаются строкой вида `public static readonly Currency USD = new (...)` внутри самого `partial`-класса, а инспекция ReSharper не считает за использование инстанцирование типа внутри него же. Поэтому аннотация здесь нужна в любом случае.

## Публичный API

Из метаданных публичного типа `EnumObject` пропадает атрибут `[UsedImplicitly]`, а на `EnumObjectItemAttribute` появляется `[MeansImplicitUse]`. Существующих потребителей это не ломает: атрибуты влияют только на подсказки IDE, сигнатуры, состав типов и поведение остаются прежними. Новых зависимостей пакетов не добавляется — `JetBrains.Annotations` уже объявлена зависимостью в `.nuspec` публикуемых пакетов, так что сборка аннотаций у потребителя есть и рефлексия по атрибутам не сломается.

## Как проверяли

- `dotnet build GlavLib.sln -c Debug` — Build succeeded, 0 Warning(s), 0 Error(s), собрались все 10 проектов решения.
- Проверка, ради которой всё делалось: `strings -a GlavLib.Abstractions/bin/Debug/net10.0/GlavLib.Abstractions.dll | grep -i "MeansImplicitUse"` выдаёт `MeansImplicitUseAttribute`. Это существенно, потому что все проекты решения проходят weaving `NullGuard.Fody`, и атрибут обязан его пережить.
- `dotnet test GlavLib.SourceGenerators.Tests/GlavLib.SourceGenerators.Tests.csproj` — Passed: 27, Failed: 0.
- `dotnet test GlavLib.Tests/GlavLib.Tests.csproj --filter 'FullyQualifiedName!~GlavLib.Tests.Db'` — Passed: 25, Failed: 2. Упали ровно два теста, падающие и на `main`: `MultiLangMessageTests.It_should_format_message` и `MultiLangMessageTests.It_should_ignore_argument_if_it_is_absent`. Причина в том, что `MultiLangMessage.Format` подставляет аргументы по шаблону `{arg:type}`, а тесты написаны на плейсхолдеры без типа; к этой правке падение отношения не имеет.

Осталось непроверенным: тесты, которым нужен PostgreSQL, — `GlavLib.Tests.Db.DbSessionFactoryTests` и весь `Sandbox/GlavLib.Sandbox.API.Tests`. В облачной среде Docker и Postgres недоступны.

Отдельно непроверяемое здесь: молчит ли инспекция Rider у потребителя. Присутствие атрибутов в метаданных выпускаемой сборки — необходимое условие, и оно выполнено и подтверждено, но сам результат в IDE проверяется только на реальном проекте-потребителе после публикации новой версии пакета. Поскольку `[UsedImplicitly]` с `EnumObject` снят, единственным механизмом остаётся `[MeansImplicitUse]` на `EnumObjectItemAttribute` — при проверке новой версии стоит убедиться именно в том, что предупреждение ушло на классах с `[EnumObjectItem]`.

Merge strategy — squash.