### PR TITLE
chore(build): обновлены версии NuGet-пакетов и GlavKod.Nuke.Components

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,52 +5,52 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Destructurama.Attributed" Version="5.3.0" />
-    <PackageVersion Include="FluentAssertions" Version="8.9.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.10.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <PackageVersion Include="NullGuard.Fody" Version="3.1.1" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="Glob" Version="1.1.9" />
-    <PackageVersion Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageVersion Include="Serilog" Version="4.3.1" />
+    <PackageVersion Include="JetBrains.Annotations" Version="2026.2.0" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Enrichers.AssemblyName" Version="2.0.0" />
     <PackageVersion Include="Serilog.Enrichers.Environment" Version="3.0.1" />
     <PackageVersion Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageVersion Include="Serilog.Expressions" Version="5.0.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
-    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageVersion Include="Serilog.Sinks.Seq" Version="9.0.0" />
-    <PackageVersion Include="YamlDotNet" Version="17.0.1" />
+    <PackageVersion Include="Serilog.Sinks.Seq" Version="9.1.0" />
+    <PackageVersion Include="YamlDotNet" Version="18.1.0" />
     <PackageVersion Include="App.Metrics.AspNetCore" Version="4.3.0" />
     <PackageVersion Include="App.Metrics.Prometheus" Version="4.3.0" />
     <PackageVersion Include="Autofac.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageVersion Include="Dapper" Version="2.1.72" />
-    <PackageVersion Include="FluentNHibernate" Version="3.4.1" />
+    <PackageVersion Include="Dapper" Version="2.1.79" />
+    <PackageVersion Include="FluentNHibernate" Version="3.5.0" />
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="Humanizer.Core.uk" Version="3.0.10" />
-    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.6" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageVersion Include="NHibernate" Version="5.6.0" />
+    <PackageVersion Include="NHibernate" Version="5.7.0" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="SharpGrip.FluentValidation.AutoValidation.Endpoints" Version="2.0.0" />
     <PackageVersion Include="GlavKod.Nuke.Components" Version="2026.8.31.62" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageVersion Include="xunit.runner.visualstudio" Version="4.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="coverlet.collector" Version="10.0.0">
+    <PackageVersion Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
     <PackageVersion Include="Serilog.Sinks.XUnit" Version="3.0.19" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.1.2" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.9.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -37,7 +37,7 @@
     <PackageVersion Include="NHibernate" Version="5.6.0" />
     <PackageVersion Include="Npgsql" Version="9.0.3" />
     <PackageVersion Include="SharpGrip.FluentValidation.AutoValidation.Endpoints" Version="2.0.0" />
-    <PackageVersion Include="GlavKod.Nuke.Components" Version="2026.4.19.54" />
+    <PackageVersion Include="GlavKod.Nuke.Components" Version="2026.8.31.62" />
     <PackageVersion Include="Nuke.Common" Version="10.1.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />


### PR DESCRIPTION
## Что изменилось

Единственный изменённый файл — `Directory.Packages.props`, в котором централизованно заданы
версии пакетов. Подняты версии девятнадцати пакетов:

| Пакет | Было | Стало |
|---|---|---|
| `GlavKod.Nuke.Components` | 2026.4.19.54 | 2026.8.31.62 |
| `Microsoft.CodeAnalysis.CSharp` | 5.3.0 | 5.9.0 |
| `Microsoft.CodeAnalysis.CSharp.Workspaces` | 5.3.0 | 5.9.0 |
| `NHibernate` | 5.6.0 | 5.7.0 |
| `FluentNHibernate` | 3.4.1 | 3.5.0 |
| `Dapper` | 2.1.72 | 2.1.79 |
| `YamlDotNet` | 17.0.1 | 18.1.0 |
| `JetBrains.Annotations` | 2025.2.4 | 2026.2.0 |
| `Serilog` | 4.3.1 | 4.4.0 |
| `Serilog.Settings.Configuration` | 10.0.0 | 10.0.1 |
| `Serilog.Sinks.Seq` | 9.0.0 | 9.1.0 |
| `Microsoft.Extensions.Configuration` | 10.0.6 | 10.0.11 |
| `Microsoft.Extensions.Configuration.Json` | 10.0.6 | 10.0.11 |
| `Microsoft.Extensions.DependencyInjection.Abstractions` | 10.0.6 | 10.0.11 |
| `Microsoft.AspNetCore.Mvc.Testing` | 10.0.6 | 10.0.11 |
| `FluentAssertions` | 8.9.0 | 8.10.0 |
| `Microsoft.NET.Test.Sdk` | 18.4.0 | 18.9.0 |
| `xunit.runner.visualstudio` | 3.1.5 | 4.0.0 |
| `coverlet.collector` | 10.0.0 | 10.0.1 |

Исходного кода правка не касается: ни один файл с кодом не изменён.

## Зачем

Основной повод — перевод сборки Nuke на `GlavKod.Nuke.Components` версии 2026.8.31.62.
Побочный полезный эффект этого обновления: на прежней версии восстановление
`build/_build.csproj` выдавало предупреждения `NU1901` и `NU1903` об известных уязвимостях
в транзитивных `NuGet.Packaging` и `System.Security.Cryptography.Xml` — на новой версии
эти предупреждения исчезли.

Остальные пакеты подняты до актуальных версий в рамках планового обновления зависимостей.

Публичный API библиотеки не затрагивается: сигнатуры, поведение и состав публичных типов
не менялись, поэтому обновление пакетов расходится по потребителям без правок с их стороны.
Отдельно стоит отметить, что `GlavKod.Nuke.Components` используется только сборкой Nuke
и в публикуемые пакеты NuGet не попадает.

## Как проверяли

| Команда | Результат |
|---|---|
| `dotnet build GlavLib.sln -c Debug` | Успешно: 0 предупреждений, 0 ошибок |
| `dotnet test GlavLib.SourceGenerators.Tests/GlavLib.SourceGenerators.Tests.csproj` | Пройдено 27 из 27 |
| `dotnet test GlavLib.Tests/GlavLib.Tests.csproj --filter 'FullyQualifiedName!~GlavLib.Tests.Db'` | Пройдено 25, упало 2 |

Упавшие два теста — `MultiLangMessageTests.It_should_format_message` и
`MultiLangMessageTests.It_should_ignore_argument_if_it_is_absent`. Они падают и на `main`
без каких-либо правок: `MultiLangMessage.Format` подставляет аргументы по шаблону
`{arg:type}`, а тесты написаны на плейсхолдеры без типа. К этому обновлению падение
отношения не имеет.

Сборка `Directory.Build.props` включает `TreatWarningsAsErrors`, поэтому чистая сборка
решения подтверждает, что обновление `Microsoft.CodeAnalysis.CSharp` не сломало
source-генераторы, а обновление `NHibernate` и `FluentNHibernate` — маппинги в `GlavLib.Db`.

Не проверялось: всё, что требует PostgreSQL, — `GlavLib.Tests.Db.DbSessionFactoryTests`
и весь `Sandbox/GlavLib.Sandbox.API.Tests`. В облачной среде нет ни Docker, ни базы,
поэтому обновление `NHibernate`, `FluentNHibernate` и `Dapper` на реальных запросах
к базе не проверено — это стоит прогнать локально при поднятом окружении (`up.ps1`,
`migrate.ps1`). Также не выполнялись цели Nuke `DotNetPack` и `PushPackages`:
новая версия `GlavKod.Nuke.Components` проверена только тем, что `build/_build.csproj`
восстанавливается и собирается.

Merge strategy — squash.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkUQbuDvYErrbA8qexRTYB)_